### PR TITLE
Set rounded bottom corners on window

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -9,6 +9,10 @@ public class MainWindow : Gtk.Window{
     private CommandHandler commandHandler = new CommandHandler();
 
     construct {
+        var style_context = get_style_context ();
+        style_context.add_class (Gtk.STYLE_CLASS_VIEW);
+        style_context.add_class ("rounded");
+
         set_default_size(Constants.APPLICATION_WIDTH, Constants.APPLICATION_HEIGHT);
         set_titlebar (headerBar);
 

--- a/src/StackManager.vala
+++ b/src/StackManager.vala
@@ -18,6 +18,7 @@ public class StackManager : Object {
     // Private constructor
     StackManager() {
         stack = new Gtk.Stack ();
+        stack.margin_bottom = 4;
         stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
     }
  


### PR DESCRIPTION
Since we've only get views touching the bottom of the window we can "cheat" a little and add a margin to easily get rounded bottom corners with minimal CSS changes