### PR TITLE
Add Ubuntu font to the runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends: cmake (>= 2.6),
 
 Package: com.github.bartzaalberg.snaptastic
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, snapd
+Depends: ${misc:Depends}, ${shlibs:Depends}, snapd, ttf-ubuntu-font-family
 Pre-Depends: dpkg (>= 1.15.6)
 Description: Snaptastic
  Manage your snap files


### PR DESCRIPTION
This makes sure that the user actually has the Ubuntu font on their system to be used