### PR TITLE
Add new Browse button to WelcomeView

### DIFF
--- a/po/com.github.bartzaalberg.snaptastic.pot
+++ b/po/com.github.bartzaalberg.snaptastic.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-19 09:17+0100\n"
+"POT-Creation-Date: 2018-07-09 11:31-1000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,58 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#: ../src/Components/HeaderBar.vala:51
-msgid "Back"
-msgstr ""
-
-#: ../src/Views/WelcomeView.vala:11
-msgid "Install Some Snaps"
-msgstr ""
-
-#: ../src/Views/WelcomeView.vala:11
-msgid "Click open to select a downloaded snap file"
-msgstr ""
-
-#: ../src/Views/WelcomeView.vala:12 ../src/ListBoxRow.vala:95
-msgid "Open"
-msgstr ""
-
-#: ../src/Views/WelcomeView.vala:12
-msgid "Browse to open a single snap file"
-msgstr ""
-
-#: ../src/Views/ProgressView.vala:7
-msgid "Please Wait..."
-msgstr ""
-
-#: ../src/Views/ProgressView.vala:7
-msgid "Operation is in progress..."
-msgstr ""
-
-#: ../src/Views/DetailView.vala:4
-msgid "Package Information"
-msgstr ""
-
-#: ../src/Views/DetailView.vala:5
-msgid "Developer"
-msgstr ""
-
-#: ../src/Views/NotFoundView.vala:7
-msgid "No snaps where found"
-msgstr ""
-
-#: ../src/Views/NotFoundView.vala:7
-msgid "Please install some"
-msgstr ""
-
-#: ../src/Dialogs/DeleteConfirm.vala:8
-msgid "Delete this application?"
-msgstr ""
-
-#: ../src/Dialogs/DeleteConfirm.vala:8
-msgid "Are you sure you want to delete this application?"
-msgstr ""
 
 #: ../src/ListBoxRow.vala:49
 msgid "Refresh"
@@ -93,6 +41,58 @@ msgstr ""
 msgid "Install this application"
 msgstr ""
 
+#: ../src/ListBoxRow.vala:95 ../src/Views/WelcomeView.vala:12
+msgid "Open"
+msgstr ""
+
 #: ../src/ListBoxRow.vala:97
 msgid "Run the application"
+msgstr ""
+
+#: ../src/Components/HeaderBar.vala:51
+msgid "Back"
+msgstr ""
+
+#: ../src/Views/WelcomeView.vala:11
+msgid "Install Some Snaps"
+msgstr ""
+
+#: ../src/Views/WelcomeView.vala:11
+msgid "Click open to select a downloaded snap file"
+msgstr ""
+
+#: ../src/Views/WelcomeView.vala:12
+msgid "Browse to open a single snap file"
+msgstr ""
+
+#: ../src/Views/ProgressView.vala:7
+msgid "Please Wait..."
+msgstr ""
+
+#: ../src/Views/ProgressView.vala:7
+msgid "Operation is in progress..."
+msgstr ""
+
+#: ../src/Views/NotFoundView.vala:7
+msgid "No snaps where found"
+msgstr ""
+
+#: ../src/Views/NotFoundView.vala:7
+msgid "Please install some"
+msgstr ""
+
+#: ../src/Views/DetailView.vala:4
+msgid "Package Information"
+msgstr ""
+
+#: ../src/Views/DetailView.vala:5
+msgid "Developer"
+msgstr ""
+
+#: ../src/Dialogs/DeleteConfirm.vala:8
+msgid "Delete this application?"
+msgstr ""
+
+#: ../src/Dialogs/DeleteConfirm.vala:8
+msgid "Are you sure you want to delete this application?"
 msgstr ""

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -9,8 +9,8 @@ public class WelcomeView : Gtk.ScrolledWindow {
 
     public WelcomeView(){
         var welcome_view = new Welcome(_("Install Some Snaps"), _("Click open to select a downloaded snap file"));
-        welcome_view.append("ubuntu-open", _("Open"), _("Browse to open a single snap file"));
-        welcome_view.append("web-browser", _("Browse"), _("Browse the Snapcraft store for a snap"));
+        welcome_view.append("ubuntu-open", _("Open Snap"), _("Browse to open a single snap file"));
+        welcome_view.append("web-browser", _("Browse the Store"), _("Browse the Snapcraft store for a snap"));
 
         welcome_view.activated.connect ((option) => {
             switch (option) {		

--- a/src/Views/WelcomeView.vala~
+++ b/src/Views/WelcomeView.vala~
@@ -10,7 +10,6 @@ public class WelcomeView : Gtk.ScrolledWindow {
     public WelcomeView(){
         var welcome_view = new Welcome(_("Install Some Snaps"), _("Click open to select a downloaded snap file"));
         welcome_view.append("ubuntu-open", _("Open"), _("Browse to open a single snap file"));
-        welcome_view.append("web-browser", _("Browse"), _("Browse the Snapcraft store for a snap"));
 
         welcome_view.activated.connect ((option) => {
             switch (option) {		
@@ -30,9 +29,6 @@ public class WelcomeView : Gtk.ScrolledWindow {
 					stackManager.setDetailPackage(package);
 					stackManager.getStack().visible_child_name = "detail-view";
 
-					break;
-				case 1:
-					Gtk.show_uri(null, "https://snapcraft.io/store", Gdk.CURRENT_TIME);
 					break;
             }
         });


### PR DESCRIPTION
[Snapcraft](https://snapcraft.io) has an online store for snaps that people can browse and search for. Although Snaptastic is great for managing snaps, the user should at least be a bit aware of this new part of the Snapcraft website. I've made a change in the `WelcomeView` that adds a button to the start page, allowing users to open the snap store in a single click. This button will open https://snapcraft.io/store in their default web browser.

![New Browse button](https://imgur.com/ddAJlno.png)

My only major concern here is that the icon for this action isn't correct.