### PR TITLE
Update Japanese translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -2,7 +2,7 @@
 #
 ca
 es
+fr
 ja
 lt
-fr
 nl

--- a/po/extra/LINGUAS
+++ b/po/extra/LINGUAS
@@ -1,2 +1,3 @@
-nl
 fr
+ja
+nl

--- a/po/extra/ja.po
+++ b/po/extra/ja.po
@@ -1,0 +1,476 @@
+# Japanese translations for extra package.
+# Copyright (C) 2019 THE extra'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the extra package.
+# Ryo Nakano <ryonakaknock3@gmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: extra\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-06-09 09:54+0900\n"
+"PO-Revision-Date: 2019-06-09 10:16+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.2.3\n"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:6
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:3
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:4
+msgid "Snaptastic"
+msgstr "Snaptastic"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:7
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:5
+msgid "A manager for snaps"
+msgstr "Snap ファイルを管理します"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:9
+msgid ""
+"Install your snaps, both downloaded and from online stores like snapcraft.io "
+"(right from the browser!). Update with one click in the app, and more! Do "
+"everything you need to do without the necessity of opening the terminal."
+msgstr ""
+"Snap ファイルをインストールします。ダウンロード済みのファイルをインストールす"
+"る方法と、snapcraft.io などのオンラインストアからブラウザーから直接インストー"
+"ルするする方法の両方に対応しています。このアプリを使えば一度のクリックでアッ"
+"プデートできます！必要な作業はすべて、ターミナルを開くことなく完結します。"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:10
+msgid "Features:"
+msgstr "機能:"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:12
+msgid "Install snap files"
+msgstr "Snap ファイルのインストール"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:13
+msgid "Update, remove, and view information about your installed snaps"
+msgstr "インストール済みの Snap アプリのアップデート、削除、情報の参照"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:14
+msgid "Search through your installed snaps"
+msgstr "インストール済みの Snap アプリの検索"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:15
+msgid "Install snaps from web a uri"
+msgstr "Web 上の URI からの Snap のインストール"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:16
+msgid "Choose between light and dark with dark mode"
+msgstr "ダークモードの選択"
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:54
+msgid "Added dark mode and tooltip shortcuts"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:56
+msgid "Added dark mode"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:57
+msgid "Added shortcuts to the button labels"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:63
+msgid "Improved performance"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:65
+msgid "Improved the performance of the list view"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:66
+msgid "Fixed Dutch grammar issues"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:72
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:74
+msgid "Added French metadata translations"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:75
+msgid "Sharpened application icons"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:81
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:83
+msgid "Added metadata translations"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:89
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:100
+msgid "Added screenshot"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:91
+msgid "Single-instancing now working"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:92
+msgid "Improved project code quality"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:93
+msgid "Remember size,position, and maximized"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:94
+msgid "Fixed bug opening welcome view from web store"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:102
+msgid "Fixed the icon not found crash"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:103
+msgid "Added screenshot for snaps"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:104
+msgid "Refactored the detail view"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:105
+msgid "Updated the screenshot for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:106
+msgid "Fixed a lot of warnings"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:107
+msgid "Added OARS rating"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:113
+msgid "Icons, single-instance, and translations fix"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:115
+msgid "Icons finally work!"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:116
+msgid "Application is now single-instance"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:117
+msgid "Translations are working again"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:123
+msgid ""
+"Fixed local snap installing, added channel support, added some shortcuts"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:125
+msgid "Fixed opening local snap files"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:126
+msgid "Added ability to install from other channels"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:127
+msgid "Channels are now shown on list and detail pages"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:128
+msgid "Added application shortcuts"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:134
+msgid "Moved to meson, apps can be opened from snaptastic again"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:136
+msgid "Moved to Meson"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:137
+msgid "Fixed the About link"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:138
+msgid "Added French translation"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:139
+msgid "Corrected some spelling"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:140
+msgid "Fixed opening apps"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:146
+msgid "Juno Fixes and more translations"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:148
+msgid "Added Catalan and spanish translations"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:149
+msgid "Aligned DetailViewBanner for Juno"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:155
+msgid "Houston CI"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:157
+msgid "Added Houston Ci and necessary changes"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:163
+msgid "Japanese translation and Lithuanian translation fix"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:165
+msgid "Added Japanese translation"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:166
+msgid "Added a fix for the Lithuanian translation"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:172
+msgid "Dutch translation and navigation bugfix"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:174
+msgid "Added dutch translation"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:175
+msgid "Added a fix for the navigation bug"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:181
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:191
+msgid "Moved to glib"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:183
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:193
+msgid "Added 'about snaptastic' action"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:184
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:194
+msgid "Moved from snap cli to snapd-glib"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:185
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:195
+msgid "Added price for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:201
+msgid "Fixed some bugs, cleaned up some code"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:203
+msgid "Removed option to select multiple snaps"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:204
+msgid "Fixed bug where sometimes wrong buttons would show up in header"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:205
+msgid "Cleaned up alot of code"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:206
+msgid "Updated language files"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:207
+msgid "Updated app description"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:213
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:215
+msgid "Added view for not yet installed packages"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:216
+msgid "Added extra screenshot for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:217
+msgid "Switched background-color and text color for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:223
+msgid "List view overhaul"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:225
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:235
+msgid "Updated the detail view"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:226
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:236
+msgid "Removed the buttons from the list view"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:227
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:238
+msgid "Removed delete and install button for the snap core"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:233
+msgid "List view overhaul, and a link to snapcraft"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:237
+msgid "Added a link to snapcraft"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:244
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:254
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:264
+msgid "Install straight from snapcraft.io!"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:246
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:256
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:266
+msgid "Application will now open on snap:// links"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:247
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:257
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:267
+msgid "You can now launch your apps from the installed view"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:248
+msgid "Fixed appdata file and changed a line for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:258
+msgid "Fixed appdata file"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:273
+msgid "The app is now Ubuntu styled"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:275
+msgid "Made welcome text Title Case"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:276
+msgid "Set rounded bottom corners on window"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:277
+msgid "Added ubuntu styling through whole app"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:278
+msgid "Fixed some error typos"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:279
+msgid "Fixed appcenter text color"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:280
+msgid "Added application to system category for appcenter"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:286
+msgid "A nicer not-found view!"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:288
+msgid "Vertical aligned delete dialog buttons"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:289
+msgid "Added a nicer view for no results"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:295
+msgid "Modified alert dialog and added snapd as dependency"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:297
+msgid "Changed alert cancel button to close button"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:298
+msgid "alert is now positioned to center of app"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:299
+msgid "Application now depends on snapd"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:300
+msgid "Updated icons"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:306
+msgid "Fixed the appdata xml"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:308
+msgid "Fixed xml"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:314
+msgid "Removed alert and fixed polkit calls"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:316
+msgid "Removed alert"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:317
+msgid "Fixed polkit calls"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:323
+msgid "Updated readme and debian/control file"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:325
+msgid "Updated readme, removed lines which dont apply"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:326
+msgid "Updated debian/control file"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:332
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:334
+msgid "First release"
+msgstr ""
+
+#: data/com.github.bartzaalberg.snaptastic.appdata.xml.in:356
+msgid "Bart Zaalberg"
+msgstr "Bart Zaalberg"
+
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:8
+msgid "com.github.bartzaalberg.snaptastic"
+msgstr "com.github.bartzaalberg.snaptastic"
+
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:13
+msgid "GUI;Snaps;"
+msgstr "GUI;Snaps;グラフィカルユーザインタフェース;スナップ;"
+
+#: data/com.github.bartzaalberg.snaptastic.desktop.in:18
+msgid "About Snaptastic"
+msgstr "Snaptastic について"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,15 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.bartzaalberg.snaptastic\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-24 17:04+0100\n"
-"PO-Revision-Date: 2019-03-24 16:53+0100\n"
-"Last-Translator: Ryo Nakano <ryonakaknock@gmail.com>\n"
+"POT-Creation-Date: 2019-06-09 09:54+0900\n"
+"PO-Revision-Date: 2019-06-09 10:01+0900\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
 "Language-Team: Japanese\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 2.2.3\n"
 
 #: src/ListBoxRow.vala:48
 msgid "Refresh"
@@ -59,11 +60,11 @@ msgstr "このアプリケーションを削除してもよろしいですか？
 
 #: src/Views/NotFoundView.vala:7
 msgid "No snaps were found"
-msgstr "Snap ファイルが見つかりません"
+msgstr "Snap アプリが見つかりません"
 
 #: src/Views/NotFoundView.vala:7
 msgid "Please install some"
-msgstr "何かインストールしてください"
+msgstr "Snap アプリをインストールしてください"
 
 #: src/Views/WelcomeView.vala:11
 msgid "Install Some Snaps"
@@ -71,11 +72,11 @@ msgstr "Snap ファイルをインストールしましょう"
 
 #: src/Views/WelcomeView.vala:11
 msgid "Click open to select a downloaded snap file"
-msgstr "[開く] をクリックしてダウンロードした Snap ファイルを選択してください"
+msgstr "\"開く\" をクリックしてダウンロードした Snap ファイルを選択してください"
 
 #: src/Views/WelcomeView.vala:12
 msgid "Browse to open a single snap file"
-msgstr "ブラウズして Snap ファイルを一つ開きます"
+msgstr "ブラウズして Snap ファイルを開きます"
 
 #: src/Views/ProgressView.vala:7
 msgid "Please Wait…"
@@ -87,19 +88,19 @@ msgstr "処理が進行しています…"
 
 #: src/Components/HeaderBar.vala:38
 msgid "Home"
-msgstr ""
+msgstr "ホーム"
 
 #: src/Components/HeaderBar.vala:39
 msgid "Go to home"
-msgstr ""
+msgstr "メインページに移動します"
 
 #: src/Components/HeaderBar.vala:43
 msgid "Updates"
-msgstr ""
+msgstr "アップデート"
 
 #: src/Components/HeaderBar.vala:44
 msgid "Go to installed applications"
-msgstr ""
+msgstr "インストール済みアプリケーションのページに移動します"
 
 #: src/Components/HeaderBar.vala:57
 msgid "Back"
@@ -107,8 +108,8 @@ msgstr "戻る"
 
 #: src/Components/HeaderBar.vala:69
 msgid "Light mode"
-msgstr ""
+msgstr "ライトモード"
 
 #: src/Components/HeaderBar.vala:70
 msgid "Dark mode"
-msgstr ""
+msgstr "ダークモード"


### PR DESCRIPTION
…more than 1 years later after my previous translation PR.

## BEFORE

![Screenshot from 2019-06-09 10-19-55](https://user-images.githubusercontent.com/26003928/59153889-2f088a00-8aa0-11e9-9063-39d200ee56de.png)

## AFTER

![Screenshot from 2019-06-09 10-02-42](https://user-images.githubusercontent.com/26003928/59153888-2e6ff380-8aa0-11e9-9db1-7493ccc05c89.png)

## Changes Summary

* Update Japanese translation for the app
* Add Japanese translation for metadata files
* Make sure of sorting LIGNUAS files alphabetically

I did not add translations for release notes intentionally, because translated strings for them will never be shown in anywhere.
